### PR TITLE
Updating CORS to be more restrictive

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 mod board;
 mod game;
-use axum::Router;
+
+use std::env;
+use axum::{http::Method, Router};
 use board::Board;
 use dotenv::dotenv;
 use futures_util::stream::StreamExt;
@@ -16,7 +18,7 @@ use socketioxide::{
 };
 use sqlx::PgPool;
 use tokio::net::TcpListener;
-use tower_http::cors::CorsLayer;
+use tower_http::cors::{AllowOrigin, CorsLayer};
 use tracing_subscriber::FmtSubscriber;
 
 #[tokio::main]
@@ -34,9 +36,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (layer, io) = SocketIo::builder().with_state(pool).build_layer();
 
     io.ns("/", on_connect);
+
+    // Get the allowed origins from the .env file
+    let allowed_origins = env::var("ALLOWED_ORIGINS")
+        .expect("ALLOWED_ORIGINS must be set");
+
+    // Split the origins by comma and collect them into a vector
+    let origins: Vec<String> = allowed_origins.split(',')
+        .map(|s| s.trim().to_string())
+        .collect();
+
+    // Convert the vector of strings into `AllowOrigin`
+    let allow_origin = AllowOrigin::list(origins.iter().map(|origin| origin.parse().unwrap()));
+
+    // Create a CORS layer
+    let cors = CorsLayer::new()
+        .allow_origin(allow_origin)
+        .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE]);
+
+
     let app = Router::new()
         .layer(layer)
-        .layer(CorsLayer::very_permissive());
+        .layer(cors);
+
 
     let listener = TcpListener::bind("0.0.0.0:3000").await?;
     println!("listening on {}", listener.local_addr()?);


### PR DESCRIPTION
### Description

This PR adds support for configuring CORS allowed origins from the `.env` file. Instead of hardcoding the origins in the code, the backend can now dynamically read the origins from the environment, making it easier to manage in different environments (development, staging, production).

### Changes:

1. Reads the `ALLOWED_ORIGINS` variable from the `.env` file.
2. Splits the comma-separated list of origins and parses them into a `Vec<String>`.
3. Configures the `CorsLayer` with the parsed origins.

### Example `.env` configuration:
         `ALLOWED_ORIGINS=http://localhost:3001,http://localhost:3000,yourec2instance`
