### PR TITLE
feat(join): hide join button if already on a room

### DIFF
--- a/app/src/lib/join.svelte
+++ b/app/src/lib/join.svelte
@@ -23,7 +23,7 @@
 >
 	<div class="space-y-4 max-w-[70%]">
 		{#if roomCode}
-		<div class="text-center text-lg text-primary-content">Share this room code</div>
+			<div class="text-center text-lg text-primary-content">Share this room code</div>
 			<div class="space-x-2 flex flex-row justify-center items-center">
 				<div
 					class="text-3xl font-bold tracking-widest text-secondary-content font-mono bg-secondary py-3 rounded-full px-12"
@@ -62,7 +62,10 @@
 			</div>
 		{:else}
 			<div class="space-x-2 flex flex-row justify-center items-center">
-				<button class="btn btn-error text-2xl px-12 py-3 h-fit" onclick={leaveRoom}>
+				<button
+					class="w-full btn btn-outline btn-neutral text-neutral hover:border-neutral hover:bg-transparent text-xl"
+					onclick={leaveRoom}
+				>
 					Leave room
 				</button>
 			</div>

--- a/app/src/lib/join.svelte
+++ b/app/src/lib/join.svelte
@@ -23,7 +23,7 @@
 >
 	<div class="space-y-4 max-w-[70%]">
 		{#if roomCode}
-		<div class="text-center text-lg text-primary-content">Share this code with your opponent to play</div>
+		<div class="text-center text-lg text-primary-content">Share this room code</div>
 			<div class="space-x-2 flex flex-row justify-center items-center">
 				<div
 					class="text-3xl font-bold tracking-widest text-secondary-content font-mono bg-secondary py-3 rounded-full px-12"

--- a/app/src/lib/join.svelte
+++ b/app/src/lib/join.svelte
@@ -21,6 +21,7 @@
 >
 	<div class="space-y-4 max-w-[70%]">
 		{#if roomCode}
+		<div class="text-center text-lg text-primary-content">Share this code with your opponent to play</div>
 			<div class="space-x-2 flex flex-row justify-center items-center">
 				<div
 					class="text-3xl font-bold tracking-widest text-secondary-content font-mono bg-secondary py-3 rounded-full px-12"
@@ -40,21 +41,23 @@
 				Create Room
 			</button>
 		{/if}
-		<div class="text-center text-lg text-primary-content">OR</div>
-		<div class="space-y-2">
-			<input
-				type="text"
-				placeholder="Enter code"
-				maxlength="4"
-				bind:value={joinCode}
-				class="input input-bordered input-primary uppercase tracking-widest placeholder-primary text-neutral text-center font-bold text-xl lg:text-3xl w-full glass"
-			/>
-			<button
-				onclick={() => joinRoom(joinCode)}
-				class="w-full btn btn-outline btn-neutral text-neutral hover:border-neutral hover:bg-transparent text-xl"
-			>
-				Join Room
-			</button>
-		</div>
+		{#if !roomCode}
+			<div class="text-center text-lg text-primary-content">OR</div>
+			<div class="space-y-2">
+				<input
+					type="text"
+					placeholder="Enter code"
+					maxlength="4"
+					bind:value={joinCode}
+					class="input input-bordered input-primary uppercase tracking-widest placeholder-primary text-neutral text-center font-bold text-xl lg:text-3xl w-full glass"
+				/>
+				<button
+					onclick={() => joinRoom(joinCode)}
+					class="w-full btn btn-outline btn-neutral text-neutral hover:border-neutral hover:bg-transparent text-xl"
+				>
+					Join Room
+				</button>
+			</div>
+		{/if}
 	</div>
 </div>

--- a/app/src/lib/join.svelte
+++ b/app/src/lib/join.svelte
@@ -62,7 +62,7 @@
 			</div>
 		{:else}
 			<div class="space-x-2 flex flex-row justify-center items-center">
-				<button class="btn btn-error text-2xl" onclick={leaveRoom}>
+				<button class="btn btn-error text-2xl px-12 py-3 h-fit" onclick={leaveRoom}>
 					Leave room
 				</button>
 			</div>

--- a/app/src/lib/join.svelte
+++ b/app/src/lib/join.svelte
@@ -7,11 +7,13 @@
 		class: className = '',
 		roomCode,
 		createRoom,
-		joinRoom
+		joinRoom,
+		leaveRoom
 	}: {
 		roomCode: string;
 		createRoom: () => void;
 		joinRoom: (code: string) => void;
+		leaveRoom: () => void;
 		class: string;
 	} = $props();
 </script>
@@ -41,8 +43,8 @@
 				Create Room
 			</button>
 		{/if}
+		<div class="text-center text-lg text-primary-content">OR</div>
 		{#if !roomCode}
-			<div class="text-center text-lg text-primary-content">OR</div>
 			<div class="space-y-2">
 				<input
 					type="text"
@@ -56,6 +58,12 @@
 					class="w-full btn btn-outline btn-neutral text-neutral hover:border-neutral hover:bg-transparent text-xl"
 				>
 					Join Room
+				</button>
+			</div>
+		{:else}
+			<div class="space-x-2 flex flex-row justify-center items-center">
+				<button class="btn btn-error text-2xl" onclick={leaveRoom}>
+					Leave room
 				</button>
 			</div>
 		{/if}

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -6,6 +6,11 @@
 	import { Users } from 'lucide-svelte';
 
 	let gameState = new State();
+
+	function leaveRoom() {
+		gameState.socket.emit('leave');
+		gameState = new State();
+	}
 </script>
 
 <div class="min-h-screen bg-base-300 py-8 px-4 sm:px-6 lg:px-8">
@@ -40,10 +45,7 @@
 							</div>
 							<button
 								class="btn btn-error text-xl"
-								onclick={() => {
-									gameState.socket.emit('leave');
-									gameState = new State();
-								}}>Leave</button
+								onclick={leaveRoom}>Leave</button
 							>
 						</div>
 					{/if}
@@ -73,6 +75,7 @@
 									roomCode={gameState.room}
 									createRoom={() => gameState.createRoom()}
 									joinRoom={(code) => gameState.joinRoom(code)}
+									leaveRoom={leaveRoom}
 								/>
 							{/if}
 						</div>


### PR DESCRIPTION
Closes #6 

#### Description of proposed changes
- Hidden the join button if the player is already on a room and there is no opponent yet
- Added leave room button instead, so the player can join a different match after pressing it
- Added text to instruct the user on what to do with the code

How it looks
![Screenshot 2024-09-30 at 16 41 21](https://github.com/user-attachments/assets/b511749f-76f8-4702-9cbc-8eaa198af848)
![Screenshot 2024-09-30 at 16 42 24](https://github.com/user-attachments/assets/190580bc-5753-42e4-a3f5-4be746e54a27)

